### PR TITLE
Update L2A_ProcessTile.py

### DIFF
--- a/sen2cor/L2A_ProcessTile.py
+++ b/sen2cor/L2A_ProcessTile.py
@@ -43,7 +43,7 @@ class L2A_ProcessTile(multiprocessing.Process):
             self.config = pickle.load(f)
             f.close()
         except:
-            stderrWrite('Cannot load configuration\n.' % picFn)
+            stderrWrite('Cannot load configuration\n.%s' % picFn)
  
         self.config._timestamp = datetime.now()
         self.scOnly = self.config.scOnly


### PR DESCRIPTION
The current code results in a TypeError, because there is nothing to format in the string, yet a variable is passed for formatting. 

My pull requests adds the formatting code, since writing the location of the config file can be useful debug information. Not passing the variable at all would also work as a fix.